### PR TITLE
Add starred repositories list to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/bundle
+starred_repositories.txt


### PR DESCRIPTION
Ignores `starred_repositories.txt`.