### PR TITLE
Make the starred repositories list a dotfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ these stars using the `:FetchStars` command.
 
     :FetchStars <github_username>
 
-This will fetch a list of your starred repositories and create a file in the
-root of this vim plugin named `starred_repositories.txt`.
+This will fetch and store a list of your starred repositories in
+`~/.starred_repositories`.
+
 
 ### FindREADME
 

--- a/doc/vim-readme.txt
+++ b/doc/vim-readme.txt
@@ -45,8 +45,8 @@ This plugin has three commands:
 --------------------------------------------------------------------------------
 2.1  FetchStars~                                                    *FetchStars*
 
-This will fetch a list of your starred repositories and create a file in the
-root of this vim plugin named starred_repostories.txt.
+This will fetch and store a list of your starred repositories in
+`~/.starred_repositories`.
 
 --------------------------------------------------------------------------------
 

--- a/lib/fetch_star_list.rb
+++ b/lib/fetch_star_list.rb
@@ -5,6 +5,6 @@ username = ARGV[0]
 
 starred_repositories = StarFetcher.fetch_stars_for_user(user: username)
 
-File.open("./starred_repositories.txt", "w") do |file|
+File.open("#{Dir.home}/.starred_repositories", "w") do |file|
   starred_repositories.each { |star| file.puts star }
 end

--- a/plugin/readme.vim
+++ b/plugin/readme.vim
@@ -2,7 +2,7 @@
 function! FetchStars(username)
   execute 'silent !ruby ~/.vim/bundle/vim-readme/lib/fetch_star_list.rb ' . a:username
 
-  if filereadable("starred_repositories.txt")
+  if !empty(glob("~/.starred_repositories"))
     echo 'Fetching of your starred repositores is complete!'
   else
     echo 'Fetch unsuccessful.'
@@ -18,9 +18,9 @@ function! OpenStarredReadme(readme)
 endfunction
 
 function! FindREADME()
-  if filereadable("starred_repositories.txt")
+  if !empty(glob("~/.starred_repositories"))
     call fzf#run({
-        \ 'source': 'grep --line-buffered --color=never -hrsi --include=starred_repositories.txt "" * ',
+        \ 'source': 'grep --line-buffered --color=never -hrsi --include=.starred_repositories "" * ~/.starred_repositories',
         \ 'down':   '40%',
         \ 'sink':   function('OpenStarredReadme')})
   else


### PR DESCRIPTION
The plugin was actually needed to fetch a list in every single directory
where you opened vim.  This PR makes the list a dotfile stored in the
user's root directory.