### PR TITLE
Allow opening a repository w/out nav to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ straight outta vim.
 
 This plugin has three commands:
 
-    :FetchStars <username>
+    :FetchStars <github_username>
     :Stargaze
-    :OpenREADME <username>/<reponame>
+    :OpenRepository <github_username>/<repository_name>
 
 The heart of this plugin lies in the `:Stargaze` command, which will allow you
 to fuzzy find (using fzf) a repository you have starred on GitHub and navigate
@@ -35,12 +35,12 @@ This will fetch and store a list of your starred repositories in
 
     :Stargaze
 
-Fuzzy find a README your list of starred repositories, created via the
+Fuzzy find a repository from your list of starred repositories, created via the
 `FetchStars` method.
 
 
-### OpenREADME
+### OpenRepository
 
-    :OpenREADME <username>/<repository_name>
+    :OpenRepository <github_username>/<repository_name>
 
-Open a specific repository's readme, i.e.: `:OpenREADME anhari/vim-stargazer`
+Open a specific repository, i.e.: `:OpenRepository anhari/vim-stargazer`

--- a/doc/vim-stargazer.txt
+++ b/doc/vim-stargazer.txt
@@ -11,12 +11,12 @@ CONTENTS                                                *vim-stargazer-contents*
       2. Usage ........................... |Usage|
         2.1  ............................... |FetchStars|
         2.2  ............................... |Stargaze|
-        2.3  ............................... |OpenREADME|
+        2.3  ............................... |OpenRepository|
 
 ==============================================================================
 ABOUT (1)                                                           *About*
 
-Navigate to repository READMEs, straight outta vim.
+Navigate to your starred repositories, straight outta vim.
 
 For full functionality, this plugin requires fzf[1] and octokit[2].
 
@@ -25,22 +25,27 @@ For full functionality, this plugin requires fzf[1] and octokit[2].
 
 The heart of this plugin lies in the |Stargaze| command, which will allow you
 to fuzzy find (using fzf) a repository you have starred on GitHub and navigate
-to its README on selection. Before using this command, you'll have to populate
+to its repository on selection. Before using this command, you'll have to populate
 these stars using the |FetchStars| command.
 
-You can also manually navigate to repository using the :OpenREADME command, like
-so:
+You can also manually navigate to repository using the :OpenRepository command,
+like so:
 
-:OpenREADME <username>/<reponame>
+:OpenRepository <github_username>/<repository_name>
+
+Also, you can navigate directly to a repository's readme section by default by
+adding the following to your vimrc:
+
+`let g:StarGazerNavigateToREADME = 1`
 
 ==============================================================================
 USAGE (2)                                                           *Usage*
 
 This plugin has three commands:
 
-:FetchStars <username>
+:FetchStars <github_username>
 :Stargaze
-:OpenREADME <username>/<reponame>
+:OpenRepository <github_username>/<repository_name>
 
 --------------------------------------------------------------------------------
 2.1  FetchStars~                                                    *FetchStars*
@@ -61,10 +66,10 @@ Fuzzy find a README your list of starred repositories, created via the
 
 --------------------------------------------------------------------------------
 
-2.3  OpenREADME~                                                    *OpenREADME*
+2.3  OpenRepository~                                            *OpenRepository*
 
-Open a specific repository's readme, i.e.:
+Open a specific repository, i.e.:
 
-:OpenREADME anhari/vim-stargazer
+:OpenRepository anhari/vim-stargazer
 
 --------------------------------------------------------------------------------

--- a/lib/fetch_star_list.rb
+++ b/lib/fetch_star_list.rb
@@ -1,9 +1,9 @@
 require "octokit"
 require_relative "./star_fetcher"
 
-username = ARGV[0]
+github_username = ARGV[0]
 
-starred_repositories = StarFetcher.fetch_stars_for_user(user: username)
+starred_repositories = StarFetcher.fetch_stars_for_user(user: github_username)
 
 File.open("#{Dir.home}/.starred_repositories", "w") do |file|
   starred_repositories.each { |star| file.puts star }

--- a/plugin/stargazer.vim
+++ b/plugin/stargazer.vim
@@ -1,5 +1,18 @@
-function! FetchStars(username)
-  execute 'silent !ruby ~/.vim/bundle/vim-stargazer/lib/fetch_star_list.rb ' . a:username
+function! s:InitVariable(var, value)
+  if !exists(a:var)
+    let escaped_value = substitute(a:value, "'", "''", "g")
+    exec 'let ' . a:var . ' = ' . "'" . escaped_value . "'"
+    return 1
+  endif
+  return 0
+endfunction
+
+function! s:InitializeVariables()
+  call s:InitVariable("g:StarGazerNavigateToREADME", 0)
+endfunction
+
+function! FetchStars(github_username)
+  execute 'silent !ruby ~/.vim/bundle/vim-stargazer/lib/fetch_star_list.rb ' . a:github_username
 
   if !empty(glob("~/.starred_repositories"))
     echo 'Fetching of your starred repositores is complete!'
@@ -8,26 +21,28 @@ function! FetchStars(username)
   endif
 endfunction
 
-function! OpenREADME(user_and_repo)
-  execute 'silent !open https:\/\/github.com\/' . a:user_and_repo . '\#readme'
-endfunction
-
-function! OpenStarredReadme(readme)
-  execute 'silent !open https:\/\/github.com\/' . a:readme . '\#readme'
+function! OpenRepository(github_user_and_repository)
+  if g:StarGazerNavigateToREADME
+    execute 'silent !open https:\/\/github.com\/' . a:github_user_and_repository . '\#readme'
+  else
+    execute 'silent !open https:\/\/github.com\/' . a:github_user_and_repository
+  endif
 endfunction
 
 function! Stargaze()
   if !empty(glob("~/.starred_repositories"))
     call fzf#run({
-        \ 'source': 'grep --line-buffered --color=never -hsi --include=.starred_repositories "" * ~/.starred_repositories',
-        \ 'down':   '40%',
-        \ 'sink':   function('OpenStarredReadme')})
+          \ 'source': 'grep --line-buffered --color=never -hsi --include=.starred_repositories "" * ~/.starred_repositories',
+          \ 'down':   '40%',
+          \ 'sink':   function('OpenRepository')})
   else
     echo "Run the FetchStars <github_username> command to populate your stars!"
   endif
 
 endfunction
 
-command! -nargs=1 OpenREADME call OpenREADME(<f-args>)
+command! -nargs=1 OpenRepository call OpenRepository(<f-args>)
 command! -nargs=1 FetchStars call FetchStars(<f-args>)
 command! -nargs=0 Stargaze call Stargaze(<f-args>)
+
+call s:InitializeVariables()

--- a/spec/lib/star_fetcher_spec.rb
+++ b/spec/lib/star_fetcher_spec.rb
@@ -3,9 +3,9 @@ require_relative '../../lib/star_fetcher'
 
 describe StarFetcher do
   it "creates a file with a user's stars" do
-    user = "anhari"
+    github_username = "anhari"
 
-    expect(StarFetcher.fetch_stars_for_user(user: user)).to eq %w[
+    expect(StarFetcher.fetch_stars_for_user(user: github_username)).to eq %w[
       lokesh/lightbox2
       jonathanslenders/ptpython
       lpil/dogma


### PR DESCRIPTION
This changes the default behavior to simply open the repository's page
on GitHub.

A user can still choose to jump directly to the README section on the
repository's homepage via the following global vim variable:

```
let g:StarGazerNavigateToREADME = 1
```

Also refactored some variable names across the board for consistency.